### PR TITLE
Add `Element` to the type of `delimiter`

### DIFF
--- a/pyleri/elements.py
+++ b/pyleri/elements.py
@@ -67,7 +67,7 @@ class Element:
     name: t.Optional[str]
 
     @staticmethod
-    def _validate_element(element: 'Element') -> 'Element':
+    def _validate_element(element: t.Union[str, 'Element']) -> 'Element':
         if isinstance(element, str):
             return Token(element)
         if isinstance(element, Element):

--- a/pyleri/list.py
+++ b/pyleri/list.py
@@ -22,7 +22,7 @@ class List(NamedElement):
     def __init__(
             self,
             element: Element,
-            delimiter: str = ',',
+            delimiter: t.Union[str, Element] = ',',
             mi: int = 0,
             ma: t.Optional[int] = None,
             opt: bool = False):


### PR DESCRIPTION
The main point of the PR is to allow `delimiter` argument of `List` to be an `Element`. At present, if the user wants to use an element as a delimiter, the have to use `typing.cast`  (or `# type: ignore`) to avoid a type error.

The PR also adds `str` as a possible type of the argument to `_validate_element`.

Neither of these should cause any change to the runtime behaviour of the library.