### PR TITLE
Don't raise UnusedElementError when used has more elems than Grammar

### DIFF
--- a/pyleri/grammar.py
+++ b/pyleri/grammar.py
@@ -127,7 +127,7 @@ class _OrderedClass(type):
             elems = {
                 elem for elem in attrs['_order']
                 if isinstance(attrs[elem], Element)}
-            if used != elems:
+            if elems - used:
                 raise UnusedElementError(
                     'Unused element(s) found: {}'.format(
                         ', '.join(elems - used)))

--- a/test/test_choice.py
+++ b/test/test_choice.py
@@ -10,6 +10,7 @@ from pyleri import (
     Sequence,
     Choice,
     Keyword,
+    Regex,
 )  # nopep8
 
 
@@ -38,6 +39,24 @@ class TestChoice(unittest.TestCase):
         self.assertTrue(grammar.parse('hi').is_valid)
         self.assertFalse(grammar.parse(' hi iris ').is_valid)
         self.assertFalse(grammar.parse(' hi sasha ').is_valid)
+
+    def test_choice_with_named_elements(self):
+        int_value = Regex(r"\d+")
+        int_value.name = "INT_VALUE"
+
+        float_value = Regex(r"\d+(\.\d+)?")
+        float_value.name = "FLOAT_VALUE"
+
+        choice = Choice(float_value, int_value)
+        grammar = create_grammar(choice)
+
+        result = grammar.parse("invalid")
+
+        expecting = {str(element) for element in result.expecting}
+
+        self.assertIn('"INT_VALUE"', expecting)
+        self.assertIn('"FLOAT_VALUE"', expecting)
+        self.assertNotIn("Regex", expecting)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Issue
===
Currently, `create_grammar` will check if all named Elements are used by comparing the `used` variable (which tracks the named elements found by `_used_checker`) with `elems` (which tracks the values assigned to the grammar). The comparison is done with an `!=` operator, which will fail for states where there are more used elements than included element.

Why make this change?
===
This change would allow users to be assign Element names outside the grammar initialization.

I noticed this while trying to add a name to a Regex element. Normally, names are added by using a class variable assignment in `Grammar`, however I have a grammar that conditionally includes Regex Elements based on user input. There are many different Regexes that could be included in the grammar, so naming them makes the `Result.expecting` easier to understand.

Steps to reproduce
===

```python
int_value = Regex(r"\d+")
int_value.name = "INT_VALUE"

float_value = Regex(r"\d+(\.\d+)?")
float_value.name = "FLOAT_VALUE"

choice = Choice(float_value, int_value)
create_grammar(choice)
```

This gives us the following state:
```
elems = {"START"}
used = {"FLOAT_VALUE", "INT_VALUE", "START"}
```

This fails the condition `if used != elems:` and raises the following exception:
```
pyleri.exceptions.UnusedElementError: Unused element(s) found: 
```

Conclusion
===
When `int_value`/`float_value` are included in the grammar, they are in `used`, but it is not in `elems`, so when initializing the grammar, this raises an `UnusedElementError`. I felt like the correct approach was to update the logic to only raise an `UnusedElementError` when there are Elements in `elems` that are not in `used`.

Let me know if there are other perspectives I should be considering. I'm not sure if it's intended for names to be manually set on Elements, but the only issue I saw was this condition, so I wanted to know if we should change it.

Great job on pyleri, btw. I love it.